### PR TITLE
block "initial" and "box" condition names

### DIFF
--- a/.changeset/ten-years-hide.md
+++ b/.changeset/ten-years-hide.md
@@ -1,0 +1,5 @@
+---
+"@embellish/react": patch
+---
+
+block "initial" and "box" condition names

--- a/packages/react/index.d.ts
+++ b/packages/react/index.d.ts
@@ -25,7 +25,9 @@ export type OnlyChars<C, S> = S extends `${infer Head}${infer Tail}`
     : never
   : unknown;
 
-export type ValidConditionName<Name> = Name extends `${Letter}${infer Tail}`
+export type ValidConditionName<Name> = Name extends "box" | "initial"
+  ? never
+  : Name extends `${Letter}${infer Tail}`
   ? OnlyChars<Letter | Digit, Tail>
   : never;
 


### PR DESCRIPTION
This prevents the use of `box` and `initial` for condition names, which would clash with the reserved namespaces of the `Box` component.