### PR TITLE
Remove namespaces

### DIFF
--- a/.changeset/sour-dogs-remember.md
+++ b/.changeset/sour-dogs-remember.md
@@ -1,0 +1,5 @@
+---
+"@embellish/react": minor
+---
+
+Removed `initial:` and component display name namespaces. Renamed `is` prop to `as`.

--- a/packages/react/src/component.d.ts
+++ b/packages/react/src/component.d.ts
@@ -60,16 +60,12 @@ export function createComponent<
             | (Conds extends Conditions<infer ConditionName>
                 ? ConditionName
                 : never)
-            | LocalConditionName}:${keyof StyleProps}`]: P extends keyof StyleProps
-        ? StyleProps[P] extends (value: any) => unknown // eslint-disable-line @typescript-eslint/no-explicit-any
-          ? Parameters<StyleProps[P]>[0]
-          : never
-        : P extends `${string}:${infer PropertyName}`
-          ? PropertyName extends keyof StyleProps
-            ? StyleProps[PropertyName] extends (value: any) => unknown // eslint-disable-line @typescript-eslint/no-explicit-any
-              ? Parameters<StyleProps[PropertyName]>[0]
-              : never
+            | LocalConditionName}:${keyof StyleProps}`]: P extends `${`${string}:` | ""}${infer PropertyName}`
+        ? PropertyName extends keyof StyleProps
+          ? StyleProps[PropertyName] extends (value: any) => unknown // eslint-disable-line @typescript-eslint/no-explicit-any
+            ? Parameters<StyleProps[PropertyName]>[0]
             : never
-          : never;
+          : never
+        : never;
     }>,
 ) => JSX.Element;

--- a/packages/react/src/component.d.ts
+++ b/packages/react/src/component.d.ts
@@ -3,7 +3,7 @@ import type {
   Conditions,
   ValidConditionName,
 } from "@embellish/core";
-import type React, { CSSProperties } from "react";
+import type { CSSProperties, JSXElementConstructor } from "react";
 
 import type {
   ComponentPropsWithRef,
@@ -17,7 +17,7 @@ export function createComponent<
   Conds,
   DefaultAs extends
     | keyof JSX.IntrinsicElements
-    | React.JSXElementConstructor<any> = "div", // eslint-disable-line @typescript-eslint/no-explicit-any
+    | JSXElementConstructor<any> = "div", // eslint-disable-line @typescript-eslint/no-explicit-any
 >(config: {
   displayName?: DisplayName & ValidComponentDisplayName<DisplayName>;
   defaultAs?: DefaultAs;
@@ -26,9 +26,10 @@ export function createComponent<
     [P in keyof StyleProps]: ValidStylePropName<P> &
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ((value: any) => {
-        [Q in keyof ReturnType<StyleProps[P]>]: Q extends keyof CSSProperties
-          ? CSSProperties[Q]
-          : never;
+        [Q in keyof ReturnType<
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          StyleProps[P] extends (value: any) => unknown ? StyleProps[P] : never
+        >]: Q extends keyof CSSProperties ? CSSProperties[Q] : never;
       });
   };
   conditions?: Conds;
@@ -45,7 +46,7 @@ export function createComponent<
     JSX.LibraryManagedAttributes<As, ComponentPropsWithRef<As>>,
     never
   > & {
-      [P in Conds extends Conditions<unknown>
+      [P in Conds extends Conditions<string>
         ? "conditions"
         : never]?: Conds extends Conditions<infer ConditionName>
         ? {
@@ -60,7 +61,7 @@ export function createComponent<
             | (Conds extends Conditions<infer ConditionName>
                 ? ConditionName
                 : never)
-            | LocalConditionName}:${keyof StyleProps}`]: P extends `${`${string}:` | ""}${infer PropertyName}`
+            | LocalConditionName}:${keyof StyleProps extends string ? keyof StyleProps : never}`]: P extends `${`${string}:` | ""}${infer PropertyName}`
         ? PropertyName extends keyof StyleProps
           ? StyleProps[PropertyName] extends (value: any) => unknown // eslint-disable-line @typescript-eslint/no-explicit-any
             ? Parameters<StyleProps[PropertyName]>[0]

--- a/packages/react/src/component.d.ts
+++ b/packages/react/src/component.d.ts
@@ -15,12 +15,12 @@ export function createComponent<
   const DisplayName extends string,
   StyleProps,
   Conds,
-  DefaultIs extends
+  DefaultAs extends
     | keyof JSX.IntrinsicElements
     | React.JSXElementConstructor<any> = "div", // eslint-disable-line @typescript-eslint/no-explicit-any
 >(config: {
   displayName: DisplayName & ValidComponentDisplayName<DisplayName>;
-  defaultIs?: DefaultIs;
+  defaultAs?: DefaultAs;
   defaultStyle?: CSSProperties;
   styleProps?: StyleProps & {
     [P in keyof StyleProps]: ValidStylePropName<P> &
@@ -34,15 +34,15 @@ export function createComponent<
   conditions?: Conds;
   fallback?: "revert-layer" | "unset";
 }): <
-  Is extends
+  As extends
     | keyof JSX.IntrinsicElements
-    | React.JSXElementConstructor<any> = DefaultIs, // eslint-disable-line @typescript-eslint/no-explicit-any
+    | React.JSXElementConstructor<any> = DefaultAs, // eslint-disable-line @typescript-eslint/no-explicit-any
   LocalConditionName extends string = never,
 >(
   props: {
-    [P in `${Uncapitalize<DisplayName>}:is`]?: Is;
+    as?: As;
   } & Omit<
-    JSX.LibraryManagedAttributes<Is, ComponentPropsWithRef<Is>>,
+    JSX.LibraryManagedAttributes<As, ComponentPropsWithRef<As>>,
     "style"
   > & {
       [P in Conds extends Conditions<unknown>

--- a/packages/react/src/component.d.ts
+++ b/packages/react/src/component.d.ts
@@ -46,7 +46,7 @@ export function createComponent<
     "style"
   > & {
       [P in Conds extends Conditions<unknown>
-        ? `${Uncapitalize<DisplayName>}:conditions`
+        ? "conditions"
         : never]?: Conds extends Conditions<infer ConditionName>
         ? {
             [P in LocalConditionName]: ValidConditionName<P> &

--- a/packages/react/src/component.d.ts
+++ b/packages/react/src/component.d.ts
@@ -19,7 +19,7 @@ export function createComponent<
     | keyof JSX.IntrinsicElements
     | React.JSXElementConstructor<any> = "div", // eslint-disable-line @typescript-eslint/no-explicit-any
 >(config: {
-  displayName: DisplayName & ValidComponentDisplayName<DisplayName>;
+  displayName?: DisplayName & ValidComponentDisplayName<DisplayName>;
   defaultAs?: DefaultAs;
   defaultStyle?: CSSProperties;
   styleProps?: StyleProps & {
@@ -43,7 +43,7 @@ export function createComponent<
     as?: As;
   } & Omit<
     JSX.LibraryManagedAttributes<As, ComponentPropsWithRef<As>>,
-    "style"
+    never
   > & {
       [P in Conds extends Conditions<unknown>
         ? "conditions"
@@ -54,17 +54,22 @@ export function createComponent<
           }
         : never;
     } & Partial<{
-      [P in `${
-        | "initial"
-        | (Conds extends Conditions<infer ConditionName>
-            ? ConditionName
-            : never)
-        | LocalConditionName}:${keyof StyleProps extends string ? keyof StyleProps : never}`]: P extends `${string}:${infer PropertyName}`
-        ? PropertyName extends keyof StyleProps
-          ? StyleProps[PropertyName] extends (value: any) => unknown // eslint-disable-line @typescript-eslint/no-explicit-any
-            ? Parameters<StyleProps[PropertyName]>[0]
-            : never
+      [P in
+        | keyof StyleProps
+        | `${
+            | (Conds extends Conditions<infer ConditionName>
+                ? ConditionName
+                : never)
+            | LocalConditionName}:${keyof StyleProps}`]: P extends keyof StyleProps
+        ? StyleProps[P] extends (value: any) => unknown // eslint-disable-line @typescript-eslint/no-explicit-any
+          ? Parameters<StyleProps[P]>[0]
           : never
-        : never;
+        : P extends `${string}:${infer PropertyName}`
+          ? PropertyName extends keyof StyleProps
+            ? StyleProps[PropertyName] extends (value: any) => unknown // eslint-disable-line @typescript-eslint/no-explicit-any
+              ? Parameters<StyleProps[PropertyName]>[0]
+              : never
+            : never
+          : never;
     }>,
 ) => JSX.Element;

--- a/packages/react/src/component.js
+++ b/packages/react/src/component.js
@@ -91,24 +91,19 @@ function stringifyValue(propertyName, value) {
 }
 
 export function createComponent({
-  displayName = "Box",
+  displayName,
   styleProps,
   defaultAs = "div",
   defaultStyle = {},
   conditions: configConditions,
   fallback: configFallback = "revert-layer",
 }) {
-  const namespace = displayName.replace(/^./, x => x.toLowerCase());
   const resolveProperty = propertyName =>
     styleProps[propertyName] || (x => ({ [propertyName]: x }));
 
   const Component = forwardRef(
     (
-      {
-        as: Component = defaultAs,
-        [`${namespace}:conditions`]: localConditions = {},
-        ...props
-      },
+      { as: Component = defaultAs, conditions: localConditions = {}, ...props },
       ref,
     ) => {
       const style = { ...defaultStyle },

--- a/packages/react/src/component.js
+++ b/packages/react/src/component.js
@@ -93,7 +93,7 @@ function stringifyValue(propertyName, value) {
 export function createComponent({
   displayName = "Box",
   styleProps,
-  defaultIs = "div",
+  defaultAs = "div",
   defaultStyle = {},
   conditions: configConditions,
   fallback: configFallback = "revert-layer",
@@ -105,7 +105,7 @@ export function createComponent({
   const Component = forwardRef(
     (
       {
-        [`${namespace}:is`]: Component = defaultIs,
+        as: Component = defaultAs,
         [`${namespace}:conditions`]: localConditions = {},
         ...props
       },

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -5,7 +5,8 @@
     "moduleResolution": "Node",
     "noEmit": true,
     "checkJs": false,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "skipLibCheck": false
   },
   "include": ["src"]
 }


### PR DESCRIPTION
I've decided that the component display namespace, as well as the `initial` namespace for style props, are probably unnecessary given that this composition pattern works with a basic `as` prop:

```tsx
<ButtonBase
  as={(props: ComponentPropsWithRef<"a">) => (
    <TextBase as="a" {...props} fontSize="sm" hover:fontSize="lg" />
  )}
  bg="black"
  fg="white"
  hover:bg="#333"
  href="https://google.com/"
>
  Hello from Box
</ButtonBase>
```